### PR TITLE
Upgrade to OpenTK 4

### DIFF
--- a/Z64Utils/F3DZEX/Render/CollisionVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/CollisionVertexDrawer.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/ColoredVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/ColoredVertexDrawer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/MatrixStack.cs
+++ b/Z64Utils/F3DZEX/Render/MatrixStack.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenTK;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/RdpVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/RdpVertexDrawer.cs
@@ -7,6 +7,7 @@ using System.Text;
 using F3DZEX.Command;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/RdpVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/RdpVertexDrawer.cs
@@ -40,7 +40,7 @@ namespace F3DZEX.Render
                 File.ReadAllText("Shaders/wireframe.geom")
             );
             _nrmShader = new ShaderHandler(
-                File.ReadAllText("Shaders/rdpvtx.vert"),
+                File.ReadAllText("Shaders/rdpVtx.vert"),
                 File.ReadAllText("Shaders/coloredVtx.frag"),
                 File.ReadAllText("Shaders/rdpVtxNrm.geom")
             );

--- a/Z64Utils/F3DZEX/Render/Renderer.cs
+++ b/Z64Utils/F3DZEX/Render/Renderer.cs
@@ -339,9 +339,12 @@ namespace F3DZEX.Render
             CheckGLErros();
             GL.Hint(HintTarget.PerspectiveCorrectionHint, HintMode.Nicest);
             var err = GL.GetError();
-            if (err == ErrorCode.InvalidEnum) {
+            if (err == ErrorCode.InvalidEnum)
+            {
                 // Ignore
-            } else if (err != ErrorCode.NoError) {
+            }
+            else if (err != ErrorCode.NoError)
+            {
                 throw new Exception($"GL.GetError() -> {err}");
             }
 

--- a/Z64Utils/F3DZEX/Render/Renderer.cs
+++ b/Z64Utils/F3DZEX/Render/Renderer.cs
@@ -334,10 +334,16 @@ namespace F3DZEX.Render
 
         private void Init()
         {
-            CheckGLErros();
             /* Init Texture */
-            GL.Hint(HintTarget.PerspectiveCorrectionHint, HintMode.Nicest);
+
             CheckGLErros();
+            GL.Hint(HintTarget.PerspectiveCorrectionHint, HintMode.Nicest);
+            var err = GL.GetError();
+            if (err == ErrorCode.InvalidEnum) {
+                // Ignore
+            } else if (err != ErrorCode.NoError) {
+                throw new Exception($"GL.GetError() -> {err}");
+            }
 
             _tex0 = new TextureHandler();
             _tex1 = new TextureHandler();

--- a/Z64Utils/F3DZEX/Render/Renderer.cs
+++ b/Z64Utils/F3DZEX/Render/Renderer.cs
@@ -334,8 +334,10 @@ namespace F3DZEX.Render
 
         private void Init()
         {
+            CheckGLErros();
             /* Init Texture */
             GL.Hint(HintTarget.PerspectiveCorrectionHint, HintMode.Nicest);
+            CheckGLErros();
 
             _tex0 = new TextureHandler();
             _tex1 = new TextureHandler();

--- a/Z64Utils/F3DZEX/Render/Renderer.cs
+++ b/Z64Utils/F3DZEX/Render/Renderer.cs
@@ -10,6 +10,7 @@ using F3DZEX.Command;
 using N64;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 using OpenTK.Platform;
 using RDP;
 using Syroot.BinaryData;

--- a/Z64Utils/F3DZEX/Render/Renderer.cs
+++ b/Z64Utils/F3DZEX/Render/Renderer.cs
@@ -433,13 +433,25 @@ namespace F3DZEX.Render
             CheckGLErros();
 
             GL.Enable(EnableCap.DepthTest);
+            CheckGLErros();
             //GL.DepthFunc(DepthFunction.Lequal);
             //GL.DepthMask(false);
             //glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_BLEND)
             //GL.TexEnv(TextureEnvTarget.TextureEnv, TextureEnvParameter.TextureEnvMode, (int)EnableCap.Blend);
             GL.Enable(EnableCap.Blend);
+            CheckGLErros();
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            CheckGLErros();
             GL.Enable(EnableCap.Texture2D);
+            var err = GL.GetError();
+            if (err == ErrorCode.InvalidEnum)
+            {
+                // Ignore
+            }
+            else if (err != ErrorCode.NoError)
+            {
+                throw new Exception($"GL.GetError() -> {err}");
+            }
             CheckGLErros();
 
             if (CurrentConfig.ShowGrid)

--- a/Z64Utils/F3DZEX/Render/ShaderHandler.cs
+++ b/Z64Utils/F3DZEX/Render/ShaderHandler.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/SimpleVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/SimpleVertexDrawer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/TextDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/TextDrawer.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Render/TexturedVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/TexturedVertexDrawer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace F3DZEX.Render
 {

--- a/Z64Utils/F3DZEX/Utils.cs
+++ b/Z64Utils/F3DZEX/Utils.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using Common;
 using OpenTK;
+using OpenTK.Mathematics;
 using Syroot.BinaryData;
 using Z64;
 

--- a/Z64Utils/Forms/CollisionViewerForm.Designer.cs
+++ b/Z64Utils/Forms/CollisionViewerForm.Designer.cs
@@ -96,7 +96,6 @@
             this.modelViewer.RenderCallback = null;
             this.modelViewer.Size = new System.Drawing.Size(871, 610);
             this.modelViewer.TabIndex = 4;
-            this.modelViewer.VSync = true;
             this.modelViewer.MouseClick += new System.Windows.Forms.MouseEventHandler(this.modelViewer_MouseClick);
             // 
             // toolStrip1

--- a/Z64Utils/Forms/CollisionViewerForm.cs
+++ b/Z64Utils/Forms/CollisionViewerForm.cs
@@ -92,7 +92,7 @@ namespace Z64.Forms
             if (_cullBack)
             {
                 GL.Enable(EnableCap.CullFace);
-                GL.CullFace(CullFaceMode.Back);
+                GL.CullFace(TriangleFace.Back);
             }
             else
             {

--- a/Z64Utils/Forms/CollisionViewerForm.cs
+++ b/Z64Utils/Forms/CollisionViewerForm.cs
@@ -12,6 +12,7 @@ using System.Windows.Forms;
 using Common;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 using OpenTK.Platform;
 using RDP;
 using Syroot.BinaryData;

--- a/Z64Utils/Forms/CollisionViewerForm.cs
+++ b/Z64Utils/Forms/CollisionViewerForm.cs
@@ -54,7 +54,6 @@ namespace Z64.Forms
             _cullBack = true;
 
             InitializeComponent();
-            Toolkit.Init();
 
             modelViewer.RenderCallback = RenderCallback;
 

--- a/Z64Utils/Forms/DListViewerForm.Designer.cs
+++ b/Z64Utils/Forms/DListViewerForm.Designer.cs
@@ -146,7 +146,6 @@
             this.modelViewer.RenderCallback = null;
             this.modelViewer.Size = new System.Drawing.Size(757, 585);
             this.modelViewer.TabIndex = 4;
-            this.modelViewer.VSync = true;
             this.modelViewer.MouseClick += new System.Windows.Forms.MouseEventHandler(this.modelViewer_MouseClick);
             // 
             // listBox_routines

--- a/Z64Utils/Forms/DListViewerForm.cs
+++ b/Z64Utils/Forms/DListViewerForm.cs
@@ -61,7 +61,6 @@ namespace Z64.Forms
             _rendererCfg = new F3DZEX.Render.Renderer.Config();
 
             InitializeComponent();
-            Toolkit.Init();
 
             _renderer = new F3DZEX.Render.Renderer(game, _rendererCfg);
             modelViewer.RenderCallback = RenderCallback;

--- a/Z64Utils/Forms/DListViewerForm.cs
+++ b/Z64Utils/Forms/DListViewerForm.cs
@@ -13,6 +13,7 @@ using Common;
 using F3DZEX.Command;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 using OpenTK.Platform;
 using RDP;
 using Syroot.BinaryData;

--- a/Z64Utils/Forms/ModelViewerControl.Designer.cs
+++ b/Z64Utils/Forms/ModelViewerControl.Designer.cs
@@ -32,8 +32,6 @@
             // 
             // ModelViewerControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Name = "ModelViewerControl";
             this.ResumeLayout(false);
 

--- a/Z64Utils/Forms/ModelViewerControl.cs
+++ b/Z64Utils/Forms/ModelViewerControl.cs
@@ -117,7 +117,7 @@ namespace Z64.Forms
                 return;
             try
             {
-                if (!Context.IsCurrent)
+                if (Context == null || !Context.IsCurrent)
                     MakeCurrent();
             }
             catch (Exception ex)

--- a/Z64Utils/Forms/ModelViewerControl.cs
+++ b/Z64Utils/Forms/ModelViewerControl.cs
@@ -9,7 +9,9 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using F3DZEX.Render;
 using OpenTK;
+using OpenTK.GLControl;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 using OpenTK.Platform;
 
 namespace Z64.Forms

--- a/Z64Utils/Forms/SkeletonViewerForm.Designer.cs
+++ b/Z64Utils/Forms/SkeletonViewerForm.Designer.cs
@@ -66,7 +66,6 @@ namespace Z64.Forms
             this.modelViewer.RenderCallback = null;
             this.modelViewer.Size = new System.Drawing.Size(506, 508);
             this.modelViewer.TabIndex = 0;
-            this.modelViewer.VSync = true;
             // 
             // treeView_hierarchy
             // 

--- a/Z64Utils/Forms/SkeletonViewerForm.cs
+++ b/Z64Utils/Forms/SkeletonViewerForm.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Windows.Forms;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 using RDP;
 using Syroot.BinaryData;
 using static Z64.Z64Object;

--- a/Z64Utils/Forms/SkeletonViewerForm.cs
+++ b/Z64Utils/Forms/SkeletonViewerForm.cs
@@ -60,7 +60,6 @@ namespace Z64.Forms
             _rendererCfg = new F3DZEX.Render.Renderer.Config();
 
             InitializeComponent();
-            Toolkit.Init();
 
             _renderer = new F3DZEX.Render.Renderer(game, _rendererCfg);
             modelViewer.RenderCallback = RenderCallback;

--- a/Z64Utils/Z64Utils.csproj
+++ b/Z64Utils/Z64Utils.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Be.Windows.Forms.HexBox" Version="1.6.1" />
+    <PackageReference Include="OpenTK" Version="4.9.3" />
     <PackageReference Include="OpenTK.GLControl" Version="4.0.2" />
     <PackageReference Include="Syroot.BinaryData" Version="5.2.2" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />

--- a/Z64Utils/Z64Utils.csproj
+++ b/Z64Utils/Z64Utils.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Be.Windows.Forms.HexBox" Version="1.6.1" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="4.0.2" />
     <PackageReference Include="Syroot.BinaryData" Version="5.2.2" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Needs testing (I only have a jank VM to test with)

- drops `VSync = true` (not implemented in OpenTK 4's GLControl)