### PR TITLE
Modernize collision drawing code (but worsen UI)

### DIFF
--- a/Z64Utils/F3DZEX/Render/CollisionVertexDrawer.cs
+++ b/Z64Utils/F3DZEX/Render/CollisionVertexDrawer.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using Z64.Forms;
 
 namespace F3DZEX.Render
 {
@@ -17,8 +18,7 @@ namespace F3DZEX.Render
             )
         {
             _attrs.LayoutAddFloat(3, VertexAttribPointerType.Float, false);
-            byte[] fakeData = new byte[] { 0, 0, 0 };
-            SetVertexData(fakeData, fakeData.Length, BufferUsageHint.StaticDraw);
+            _attrs.LayoutAddFloat(3, VertexAttribPointerType.Float, false);
         }
 
         public void SendProjViewMatrices(ref Matrix4 proj, ref Matrix4 view)
@@ -32,6 +32,54 @@ namespace F3DZEX.Render
         public void SendColor(Color color)
         {
             _shader.Send("u_Color", color);
+        }
+
+        public void SetDataTriangles(
+            CollisionViewerForm.RenderColPoly[] polys,
+            BufferUsageHint hint
+        )
+        {
+            float[] data = new float[3 * (3 + 3) * polys.Length];
+            int i = 0;
+            foreach (var poly in polys)
+            {
+                for (int j = 0; j < 3; j++)
+                {
+                    data[i++] = poly.Points[j][0];
+                    data[i++] = poly.Points[j][1];
+                    data[i++] = poly.Points[j][2];
+                    data[i++] = (float)poly.Normal.X / 0x7FFF;
+                    data[i++] = (float)poly.Normal.Y / 0x7FFF;
+                    data[i++] = (float)poly.Normal.Z / 0x7FFF;
+                }
+            }
+            SetVertexData(data, sizeof(float) * data.Length, hint);
+        }
+
+        public void SetDataLines(CollisionViewerForm.RenderColPoly[] polys, BufferUsageHint hint)
+        {
+            float[] data = new float[3 * 2 * (3 + 3) * polys.Length];
+            int i = 0;
+            foreach (var poly in polys)
+            {
+                for (int j = 0; j < 3; j++)
+                {
+                    data[i++] = poly.Points[j][0];
+                    data[i++] = poly.Points[j][1];
+                    data[i++] = poly.Points[j][2];
+                    data[i++] = (float)poly.Normal.X / 0x7FFF;
+                    data[i++] = (float)poly.Normal.Y / 0x7FFF;
+                    data[i++] = (float)poly.Normal.Z / 0x7FFF;
+
+                    data[i++] = poly.Points[(j + 1) % 3][0];
+                    data[i++] = poly.Points[(j + 1) % 3][1];
+                    data[i++] = poly.Points[(j + 1) % 3][2];
+                    data[i++] = (float)poly.Normal.X / 0x7FFF;
+                    data[i++] = (float)poly.Normal.Y / 0x7FFF;
+                    data[i++] = (float)poly.Normal.Z / 0x7FFF;
+                }
+            }
+            SetVertexData(data, sizeof(float) * data.Length, hint);
         }
     }
 }

--- a/Z64Utils/F3DZEX/Render/Renderer.cs
+++ b/Z64Utils/F3DZEX/Render/Renderer.cs
@@ -282,7 +282,6 @@ namespace F3DZEX.Render
         RdpVertexDrawer? _rdpVtxDrawer;
         SimpleVertexDrawer? _gridDrawer;
         ColoredVertexDrawer? _axisDrawer;
-        CollisionVertexDrawer? _collisionDrawer;
         TextDrawer? _textDrawer;
         TextureHandler? _tex0;
         TextureHandler? _tex1;
@@ -316,7 +315,6 @@ namespace F3DZEX.Render
             nameof(_rdpVtxDrawer),
             nameof(_gridDrawer),
             nameof(_axisDrawer),
-            nameof(_collisionDrawer),
             nameof(_textDrawer),
             nameof(_tex0),
             nameof(_tex1)
@@ -328,7 +326,6 @@ namespace F3DZEX.Render
             Debug.Assert(_rdpVtxDrawer != null);
             Debug.Assert(_gridDrawer != null);
             Debug.Assert(_axisDrawer != null);
-            Debug.Assert(_collisionDrawer != null);
             Debug.Assert(_textDrawer != null);
             Debug.Assert(_tex0 != null);
             Debug.Assert(_tex1 != null);
@@ -367,7 +364,6 @@ namespace F3DZEX.Render
             _rdpVtxDrawer = new RdpVertexDrawer();
             _gridDrawer = new SimpleVertexDrawer();
             _axisDrawer = new ColoredVertexDrawer();
-            _collisionDrawer = new CollisionVertexDrawer();
             _textDrawer = new TextDrawer();
 
             float[] vertices = RenderHelper.GenerateGridVertices(CurrentConfig.GridScale, 6, false);
@@ -424,7 +420,6 @@ namespace F3DZEX.Render
 
             _gridDrawer.SendProjViewMatrices(ref proj, ref view);
             _axisDrawer.SendProjViewMatrices(ref proj, ref view);
-            _collisionDrawer.SendProjViewMatrices(ref proj, ref view);
             _rdpVtxDrawer.SendProjViewMatrices(ref proj, ref view);
             _rdpVtxDrawer.SendInitialColors(CurrentConfig);
             CheckGLErros();
@@ -434,7 +429,6 @@ namespace F3DZEX.Render
             _rdpVtxDrawer.SendModelMatrix(ModelMtxStack.Top());
             _gridDrawer.SendModelMatrix(Matrix4.Identity);
             _axisDrawer.SendModelMatrix(Matrix4.Identity);
-            _collisionDrawer.SendModelMatrix(Matrix4.Identity);
             CheckGLErros();
 
             _rdpVtxDrawer.SendHighlightColor(CurrentConfig.HighlightColor);
@@ -473,25 +467,6 @@ namespace F3DZEX.Render
             }
 
             CheckGLErros();
-        }
-
-        // This whole thing is a pretty silly hack to prevent the collision viewer from reusing
-        // _axisDrawer's shader while drawing collision polygons.
-        public void PrepareForCollisionRender()
-        {
-            AssertInitialized();
-            if (CurrentConfig.RenderMode == RdpVertexDrawer.ModelRenderMode.Wireframe)
-            {
-                GL.PolygonMode(MaterialFace.Front, PolygonMode.Line);
-                _collisionDrawer.SendColor(CurrentConfig.WireframeColor);
-            }
-            else
-            {
-                GL.PolygonMode(MaterialFace.Front, PolygonMode.Fill);
-                _collisionDrawer.SendColor(CurrentConfig.HighlightColor);
-            }
-
-            _collisionDrawer.Draw(PrimitiveType.Lines);
         }
 
         public Dlist GetDlist(uint vaddr)

--- a/Z64Utils/Shaders/collisionVtx.vert
+++ b/Z64Utils/Shaders/collisionVtx.vert
@@ -1,6 +1,7 @@
 ﻿#version 330 core
 
 layout (location = 0) in vec3 pos;
+layout (location = 1) in vec3 normal;
 
 uniform vec4 u_Color;
 uniform mat4 u_Projection;
@@ -12,5 +13,5 @@ out vec4 v_VtxColor;
 void main()
 {
 	gl_Position = u_Projection * u_View * u_Model * vec4(pos, 1);
-	v_VtxColor = u_Color;
+	v_VtxColor = u_Color * (0.3 + dot(u_View * vec4(normal,0), vec4(0,0,0.7,0)));
 }


### PR DESCRIPTION
Improvements:
- no longer uses antique opengl style (glbegin/end)
- shaded rendering, drawing in solid (now default) no longer looks flat

Worsened UI:
- no config for colors, the "render settings" button instead directly toggles wireframe

oot's object_box (treasure chest) collision:

<details>

![image](https://github.com/user-attachments/assets/0db51a72-a7f5-4c69-b60a-45d7225ec5af)

![image](https://github.com/user-attachments/assets/9553b271-a3ce-403f-a474-a68340796cfb)

</details>